### PR TITLE
Fix errors in install.rdf and binding preference window

### DIFF
--- a/addon/install.rdf
+++ b/addon/install.rdf
@@ -18,7 +18,7 @@
         em:multiprocessCompatible="true"
         em:bootstrap="true">>
         <em:type>2</em:type>
-        <em:targetApplication RDF:resource="rdf:#$x61SL3"/>
+        <!-- <em:targetApplication RDF:resource="rdf:#$x61SL3"/> -->
         <em:targetApplication>
             <Description>
                 <em:id>zotero@chnm.gmu.edu</em:id>

--- a/src/events.ts
+++ b/src/events.ts
@@ -59,7 +59,7 @@ class AddonEvents extends AddonModule {
   public initPrefs() {
     this._Addon.toolkit.Tool.log(this._Addon.rootURI);
     const prefOptions = {
-      pluginID: config.addonID,
+      id: config.addonID.replace(/[@\.#]/g,  '-'),  // Replace invalid characters in CSS selector
       src: this._Addon.rootURI + "chrome/content/preferences.xhtml",
       label: this._Addon.locale.getString("prefs.title"),
       image: `chrome://${config.addonRef}/content/icons/favicon.png`,


### PR DESCRIPTION
1. `RDF:resource="rdf:#$x61SL3"` will throw an invalid message in Zotero console
2. `prefOptions` key `pluginID` should be `id`, `id` is used in `toolkit`'s code.  Maybe you can update this key in `toolkit`. `pluginID` is like an email address and contains invalid characters `@|.` for CSS selector, these characters will be replaced by `-`
 
https://github.com/windingwind/zotero-plugin-toolkit/blob/b31dc51efb9904618372fbe12752dd27d252c496/src/compat.ts#L336

