### PR TITLE
fix(script): put path into `""`

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -17,7 +17,7 @@ if (args.help || args.h) {
 const zoteroPath = exec[args.zotero || args.z || Object.keys(exec)[0]];
 const profile = args.profile || args.p;
 
-const startZotero = `${zoteroPath} --debugger --purgecaches ${
+const startZotero = `"${zoteroPath}" --debugger --purgecaches ${
   profile ? `-p ${profile}` : ""
 }`;
 


### PR DESCRIPTION
Wrap the path in  inverted commas to prevent errors caused by spaces in the path.

```json
// zotero-cmd.json
{
  "usage": "Copy and rename this file to zotero-cmd.json. Edit the cmd.",
  "killZoteroWindows": "taskkill /f /im zotero.exe",
  "killZoteroUnix": "kill -9 $(ps -x | grep zotero)",
  "exec": {
    "6": "D:\\Program Files\\Zotero\\zotero.exe",
    "7": ""
  }
}
```

```bash
*  正在执行任务: npm run start-z6 

npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.

> zotero-format-metadata@0.0.1 start-z6
> node scripts/start.js --z 6

'D:\Program' �����ڲ����ⲿ���Ҳ���ǿ����еĳ���
�������ļ�
node:child_process:902
    throw err;
    ^

Error: Command failed: D:\Program Files\Zotero\zotero.exe --debugger --purgecaches
'D:\Program' �����ڲ����ⲿ���Ҳ���ǿ����еĳ���
���������ļ���

    at checkExecSyncError (node:child_process:828:11)
    at execSync (node:child_process:899:15)
    at Object.<anonymous> (D:\Code\zotero-format-metadata\scripts\start.js:24:1)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
    at node:internal/main/run_main_module:17:47 {
  status: 1,
  signal: null,
  output: [
    null,
    Buffer(0) [Uint8Array] [],
    Buffer(69) [Uint8Array] [
       39,  68,  58,  92,  80, 114, 111, 103, 114,  97,
      109,  39,  32, 178, 187, 202, 199, 196, 218, 178,
      191, 187, 242, 205, 226, 178, 191, 195, 252, 193,
      238, 163, 172, 210, 178, 178, 187, 202, 199, 191,
      201, 212, 203, 208, 208, 181, 196, 179, 204, 208,
      242,  13,  10, 187, 242, 197, 250, 180, 166, 192,
      237, 206, 196, 188, 254, 161, 163,  13,  10
    ]
  ],
  pid: 24824,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(69) [Uint8Array] [
     39,  68,  58,  92,  80, 114, 111, 103, 114,  97,
    109,  39,  32, 178, 187, 202, 199, 196, 218, 178,
    191, 187, 242, 205, 226, 178, 191, 195, 252, 193,
    238, 163, 172, 210, 178, 178, 187, 202, 199, 191,
    201, 212, 203, 208, 208, 181, 196, 179, 204, 208,
    242,  13,  10, 187, 242, 197, 250, 180, 166, 192,
    237, 206, 196, 188, 254, 161, 163,  13,  10
  ]
}

 *  终端进程“C:\Program Files\Git\bin\bash.exe '--login', '-i', '-c', 'npm run start-z6'”已终止，退出代码: 1。 
 *  终端将被任务重用，按任意键关闭。 
```

The script works fine after adding the inverted commas.