### PR TITLE
Z7-related: remove zo6 code, add homepage url, and add vscode-fluent

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "macabeus.vscode-fluent"
+  ]
 }

--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -71,17 +71,13 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
     rootURI = resourceURI.spec;
   }
 
-  if (Zotero.platformMajorVersion >= 102) {
-    var aomStartup = Components.classes[
-      "@mozilla.org/addons/addon-manager-startup;1"
-    ].getService(Components.interfaces.amIAddonManagerStartup);
-    var manifestURI = Services.io.newURI(rootURI + "manifest.json");
-    chromeHandle = aomStartup.registerChrome(manifestURI, [
-      ["content", "__addonRef__", rootURI + "chrome/content/"],
-    ]);
-  } else {
-    setDefaultPrefs(rootURI);
-  }
+  var aomStartup = Components.classes[
+    "@mozilla.org/addons/addon-manager-startup;1"
+  ].getService(Components.interfaces.amIAddonManagerStartup);
+  var manifestURI = Services.io.newURI(rootURI + "manifest.json");
+  chromeHandle = aomStartup.registerChrome(manifestURI, [
+    ["content", "__addonRef__", rootURI + "chrome/content/"],
+  ]);
 
   /**
    * Global variables for plugin code.
@@ -124,27 +120,3 @@ function shutdown({ id, version, resourceURI, rootURI }, reason) {
 }
 
 function uninstall(data, reason) {}
-
-// Loads default preferences from defaults/preferences/prefs.js in Zotero 6
-function setDefaultPrefs(rootURI) {
-  var branch = Services.prefs.getDefaultBranch("");
-  var obj = {
-    pref(pref, value) {
-      switch (typeof value) {
-        case "boolean":
-          branch.setBoolPref(pref, value);
-          break;
-        case "string":
-          branch.setStringPref(pref, value);
-          break;
-        case "number":
-          branch.setIntPref(pref, value);
-          break;
-        default:
-          Zotero.logError(`Invalid type '${typeof value}' for pref '${pref}'`);
-      }
-    },
-  };
-  Zotero.getMainWindow().console.log(rootURI + "prefs.js");
-  Services.scriptloader.loadSubScript(rootURI + "prefs.js", obj);
-}

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -3,6 +3,7 @@
   "name": "__addonName__",
   "version": "__buildVersion__",
   "description": "__description__",
+  "homepage_url": "__homepage__",
   "author": "__author__",
   "icons": {
     "48": "chrome/content/icons/favicon@0.5x.png",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -131,13 +131,9 @@ async function main() {
 
   const optionsAddon = {
     files: [
-      join(buildDir, "**/*.rdf"),
-      join(buildDir, "**/*.dtd"),
-      join(buildDir, "**/*.xul"),
       join(buildDir, "**/*.xhtml"),
       join(buildDir, "**/*.json"),
       join(buildDir, "addon/prefs.js"),
-      join(buildDir, "addon/chrome.manifest"),
       join(buildDir, "addon/manifest.json"),
       join(buildDir, "addon/bootstrap.js"),
       "update.json",


### PR DESCRIPTION
- remove zo6 code
- add homepage url into manifest, it will show in addons manager. https://github.com/zotero/make-it-red/commit/1812f02971e043491e4b32941b265f10ac573e90#diff-79753a25a9c047aaef46f633e92a83f7f7ba02fb2bbc68f72970fc05aff7a7f5
   
  ![image](https://github.com/windingwind/zotero-plugin-template/assets/44738481/9950e099-151e-49a8-9353-6bb61f1a9595)

- fluent vscode plugin