### PR TITLE
Add addonRef prefix for ftl

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -142,7 +142,7 @@ async function main() {
   );
   replaceTo.push(...Object.values(config));
 
-  replaceFrom.push(/(data-l10n-id=")(.*")/gm);
+  replaceFrom.push(/(data-l10n-id=")(\S*")/gm);
   replaceTo.push(`$1${config.addonRef}-$2`);
 
   const optionsAddon = {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -178,7 +178,7 @@ function replaceString() {
             `${match[1]}="${config.addonRef}-${match[2]}"`
           );
         } else {
-          localeMessageMiss.add(match[1]);
+          localeMessageMiss.add(match[2]);
         }
       });
       return input;

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -120,6 +120,7 @@ async function main() {
       __env__: `"${env.NODE_ENV}"`,
     },
     bundle: true,
+    target: "firefox102",
     outfile: join(buildDir, "addon/chrome/content/scripts/index.js"),
     // Don't turn minify on
     // minify: true,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -18,8 +18,9 @@ import details from "../package.json" assert { type: "json" };
 
 const { name, author, description, homepage, version, config } = details;
 
-const localeMessage = new Set();
-const localeMessageMiss = new Set();
+const t = new Date();
+const buildTime = dateFormat("YYYY-mm-dd HH:MM:SS", new Date());
+const buildDir = "build";
 
 function copyFileSync(source, target) {
   var targetFile = target;
@@ -87,69 +88,32 @@ function dateFormat(fmt, date) {
   return fmt;
 }
 
-function addAddonRefToFlt(fltContent) {
-  const lines = fltContent.split("\n");
-  const prefixedLines = lines.map((line) => {
-    // https://regex101.com/r/lQ9x5p/1
-    const match = line.match(
-      /^(?<message>[a-zA-Z]\S*)([ ]*=[ ]*)(?<pattern>.*)$/m
-    );
-    if (match) {
-      localeMessage.add(match.groups.message);
-      return `${config.addonRef}-${line}`;
-    } else {
-      return line;
+function renameLocaleFiles() {
+  const localeDir = join(buildDir, "addon/locale");
+  const localeFolders = readdirSync(localeDir, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+
+  for (const localeSubFolder of localeFolders) {
+    const localeSubDir = join(localeDir, localeSubFolder);
+    const localeSubFiles = readdirSync(localeSubDir, {
+      withFileTypes: true,
+    })
+      .filter((dirent) => dirent.isFile())
+      .map((dirent) => dirent.name);
+
+    for (const localeSubFile of localeSubFiles) {
+      if (localeSubFile.endsWith(".ftl")) {
+        renameSync(
+          join(localeSubDir, localeSubFile),
+          join(localeSubDir, `${config.addonRef}-${localeSubFile}`)
+        );
+      }
     }
-  });
-  return prefixedLines.join("\n");
+  }
 }
 
-function replaceLocaleIdInXHtml(input) {
-  const matchs = [...input.matchAll(/(data-l10n-id)="(\S*)"/g)];
-  matchs.map((match) => {
-    if (localeMessage.has(match[2])) {
-      input = input.replace(
-        match[0],
-        `${match[1]}="${config.addonRef}-${match[2]}"`
-      );
-    } else {
-      localeMessageMiss.add(match[1]);
-    }
-  });
-  return input;
-}
-
-async function main() {
-  const t = new Date();
-  const buildTime = dateFormat("YYYY-mm-dd HH:MM:SS", t);
-  const buildDir = "build";
-
-  console.log(
-    `[Build] BUILD_DIR=${buildDir}, VERSION=${version}, BUILD_TIME=${buildTime}, ENV=${[
-      env.NODE_ENV,
-    ]}`
-  );
-
-  clearFolder(buildDir);
-
-  copyFolderRecursiveSync("addon", buildDir);
-
-  copyFileSync("update-template.json", "update.json");
-
-  await build({
-    entryPoints: ["src/index.ts"],
-    define: {
-      __env__: `"${env.NODE_ENV}"`,
-    },
-    bundle: true,
-    target: "firefox102",
-    outfile: join(buildDir, "addon/chrome/content/scripts/index.js"),
-    // Don't turn minify on
-    // minify: true,
-  }).catch(() => exit(1));
-
-  console.log("[Build] Run esbuild OK");
-
+function replaceString() {
   const replaceFrom = [
     /__author__/g,
     /__description__/g,
@@ -180,14 +144,45 @@ async function main() {
 
   const replaceResult = sync(optionsAddon);
 
+  const localeMessage = new Set();
+  const localeMessageMiss = new Set();
+
   const replaceResultFlt = sync({
     files: [join(buildDir, "addon/**/*.ftl")],
-    processor: [addAddonRefToFlt],
+    processor: (fltContent) => {
+      const lines = fltContent.split("\n");
+      const prefixedLines = lines.map((line) => {
+        // https://regex101.com/r/lQ9x5p/1
+        const match = line.match(
+          /^(?<message>[a-zA-Z]\S*)([ ]*=[ ]*)(?<pattern>.*)$/m
+        );
+        if (match) {
+          localeMessage.add(match.groups.message);
+          return `${config.addonRef}-${line}`;
+        } else {
+          return line;
+        }
+      });
+      return prefixedLines.join("\n");
+    },
   });
 
   const replaceResultXhtml = sync({
     files: [join(buildDir, "addon/**/*.xhtml")],
-    processor: [replaceLocaleIdInXHtml],
+    processor: (input) => {
+      const matchs = [...input.matchAll(/(data-l10n-id)="(\S*)"/g)];
+      matchs.map((match) => {
+        if (localeMessage.has(match[2])) {
+          input = input.replace(
+            match[0],
+            `${match[1]}="${config.addonRef}-${match[2]}"`
+          );
+        } else {
+          localeMessageMiss.add(match[1]);
+        }
+      });
+      return input;
+    },
   });
 
   console.log(
@@ -206,32 +201,45 @@ async function main() {
       )}] do not exsit in addon's locale files.`
     );
   }
+}
+
+async function esbuild() {
+  await build({
+    entryPoints: ["src/index.ts"],
+    define: {
+      __env__: `"${env.NODE_ENV}"`,
+    },
+    bundle: true,
+    target: "firefox102",
+    outfile: join(buildDir, "addon/chrome/content/scripts/index.js"),
+    // Don't turn minify on
+    // minify: true,
+  }).catch(() => exit(1));
+}
+
+async function main() {
+  console.log(
+    `[Build] BUILD_DIR=${buildDir}, VERSION=${version}, BUILD_TIME=${buildTime}, ENV=${[
+      env.NODE_ENV,
+    ]}`
+  );
+
+  clearFolder(buildDir);
+
+  copyFolderRecursiveSync("addon", buildDir);
+
+  copyFileSync("update-template.json", "update.json");
+
+  await esbuild();
+
+  console.log("[Build] Run esbuild OK");
+
+  replaceString();
 
   console.log("[Build] Replace OK");
 
   // Walk the builds/addon/locale folder's sub folders and rename *.ftl to addonRef-*.ftl
-  const localeDir = join(buildDir, "addon/locale");
-  const localeFolders = readdirSync(localeDir, { withFileTypes: true })
-    .filter((dirent) => dirent.isDirectory())
-    .map((dirent) => dirent.name);
-
-  for (const localeSubFolder of localeFolders) {
-    const localeSubDir = join(localeDir, localeSubFolder);
-    const localeSubFiles = readdirSync(localeSubDir, {
-      withFileTypes: true,
-    })
-      .filter((dirent) => dirent.isFile())
-      .map((dirent) => dirent.name);
-
-    for (const localeSubFile of localeSubFiles) {
-      if (localeSubFile.endsWith(".ftl")) {
-        renameSync(
-          join(localeSubDir, localeSubFile),
-          join(localeSubDir, `${config.addonRef}-${localeSubFile}`)
-        );
-      }
-    }
-  }
+  renameLocaleFiles();
 
   console.log("[Build] Addon prepare OK");
 

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -63,16 +63,17 @@ function _getString(
   localString: string,
   options: { branch?: string | undefined; args?: Record<string, unknown> } = {}
 ): string {
+  const localStringWithPrefix = `${config.addonRef}-${localString}`;
   const { branch, args } = options;
   const pattern = addon.data.locale?.current.formatMessagesSync([
-    { id: localString, args },
+    { id: localStringWithPrefix, args },
   ])[0];
   if (!pattern) {
-    return localString;
+    return localStringWithPrefix;
   }
   if (branch && pattern.attributes) {
-    return pattern.attributes[branch] || localString;
+    return pattern.attributes[branch] || localStringWithPrefix;
   } else {
-    return pattern.value || localString;
+    return pattern.value || localStringWithPrefix;
   }
 }


### PR DESCRIPTION
## 问题

flt里的键还是需要加上addonref比较好，同样的键会被覆盖，应该是只用第一次读取到的。

虽然我觉得这个本应该zotero内部解决的。

![1689072876692](https://github.com/windingwind/zotero-plugin-template/assets/44738481/4ddd34f7-2bca-4b8f-8718-0e54d8c8204b)

## 这个 PR

在构建过程中，通过正则表达式匹配到所有的 ftl message，对其增加前缀 `addonRef`，

- 对 ftl 文件，为每一个以字母起始的行添加前缀，正则表达式测试结果：https://regex101.com/r/lQ9x5p/1
- 对 xhtml 文件，替换`data-l10n-id="`，测试结果：https://regex101.com/r/81sQm4/2
- 对 `getString()` ，自动为传入的 string 添加 addonRef

在当前模板插件和我的插件里工作良好。

为什么不在 ftl 里用 `__addonRef__` 做替换： `__` 会破坏 vscode-fluent 的语法检查。
手动添加这一值有点麻烦，对于现有插件来说。

此外，为 esbuild 添加了 target：firefox102，以避免：
![image](https://github.com/windingwind/zotero-plugin-template/assets/44738481/0b6649b1-7107-4a79-8d04-18e50d328f03)
