### PR TITLE
Auto update `<profile>/extensions/${addonID}` before start Zotero

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,30 +189,28 @@ npm run release
 3. Copy zotero command line config file. Modify the commands that starts your installation of the beta Zotero.
 
    > (Optional) Do this only once: Start the beta Zotero with `/path/to/zotero -p`. Create a new profile and use it as your development profile.
-   > Use `/path/to/zotero -p {profile_name}` to specify which profile to run with.
+   > Put the path of the profile into the `profilePath` in `zotero-cmd.json` to specify which profile to use.
 
    ```sh
    cp ./scripts/zotero-cmd-default.json ./scripts/zotero-cmd.json
    vim ./scripts/zotero-cmd.json
    ```
 
-4. Setup plugin development environment following this [link](https://www.zotero.org/support/dev/client_coding/plugin_development#setting_up_a_plugin_development_environment).
+4. Build plugin and restart Zotero with `npm run restart`.
 
-5. Build plugin and restart Zotero with `npm run restart`.
+5. Launch Firefox 102 (Zotero 7)
 
-6. Launch Firefox 102 (Zotero 7)
-
-7. In Firefox, go to devtools, go to settings, click "enable remote debugging" and the one next to it that's also about debugging
+6. In Firefox, go to devtools, go to settings, click "enable remote debugging" and the one next to it that's also about debugging
 
    > Enter `about:debugging#/setup` in FF 102.
 
-8. In Zotero, go to setting, advanced, config editor, look up "debugging" and click on "allow remote debugging".
+7. In Zotero, go to setting, advanced, config editor, look up "debugging" and click on "allow remote debugging".
 
-9. Connect to Zotero in Firefox. In FF 102, enter `localhost:6100` in the bottom input of remote-debugging page and click `add`.
+8. Connect to Zotero in Firefox. In FF 102, enter `localhost:6100` in the bottom input of remote-debugging page and click `add`.
 
-10. Click `connect` in the leftside-bar of Firefox remote-debugging page.
+9. Click `connect` in the leftside-bar of Firefox remote-debugging page.
 
-11. Click "Inspect Main Process"
+10. Click "Inspect Main Process"
 
 ### Auto Hot Reload
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "esbuild": "^0.18.1",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",
-    "minimist": "^1.2.8",
     "prettier": "2.8.8",
     "release-it": "^15.10.3",
     "replace-in-file": "^6.3.5",

--- a/scripts/reload.mjs
+++ b/scripts/reload.mjs
@@ -1,20 +1,13 @@
-import { exit, argv } from "process";
-import minimist from "minimist";
+import { exit } from "process";
 import { execSync } from "child_process";
 import details from "../package.json" assert { type: "json" };
-const { addonID, addonName } = details.config;
-const version = details.version;
 import cmd from "./zotero-cmd.json" assert { type: "json" };
-const { exec } = cmd;
 
-// Run node reload.js -h for help
-const args = minimist(argv.slice(2));
+const { addonID, addonName } = details.config;
+const { version } = details;
+const { zoteroBinPath, profilePath } = cmd.exec;
 
-const zoteroPath = exec[args.zotero || args.z || Object.keys(exec)[0]];
-const profile = args.profile || args.p;
-const startZotero = `${zoteroPath} --debugger --purgecaches ${
-  profile ? `-p ${profile}` : ""
-}`;
+const startZotero = `${zoteroBinPath} --debugger --purgecaches -profile ${profilePath}`;
 
 const script = `
 (async () => {

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -1,28 +1,46 @@
-import process from "process";
 import { execSync } from "child_process";
 import { exit } from "process";
-import minimist from "minimist";
+import { existsSync, writeFileSync, readFileSync } from "fs";
+import { join, resolve } from "path";
+import details from "../package.json" assert { type: "json" };
 import cmd from "./zotero-cmd.json" assert { type: "json" };
-const { exec } = cmd;
 
-// Run node start.js -h for help
-const args = minimist(process.argv.slice(2));
+const { addonID } = details.config;
+const { zoteroBinPath, profilePath, dataDir } = cmd.exec;
 
-if (args.help || args.h) {
-  console.log("Start Zotero Args:");
-  console.log(
-    "--zotero(-z): Zotero exec key in zotero-cmd.json. Default the first one."
-  );
-  console.log("--profile(-p): Zotero profile name.");
-  exit(0);
+if (!existsSync(zoteroBinPath)) {
+  throw new Error("Zotero bin do no exist.");
 }
 
-const zoteroPath = exec[args.zotero || args.z || Object.keys(exec)[0]];
-const profile = args.profile || args.p;
+if (existsSync(profilePath)) {
+  const addonProxyFilePath = join(profilePath, `extensions/${addonID}`);
+  if (!existsSync(addonProxyFilePath)) {
+    console.log("Addon proxy file do not exist, creating it.");
+    writeFileSync(addonProxyFilePath, resolve("build/addon"));
+  }
 
-const startZotero = `${zoteroPath} --debugger --purgecaches ${
-  profile ? `-p ${profile}` : ""
-}`;
+  const prefsPath = join(profilePath, "prefs.js");
+  if (existsSync(prefsPath)) {
+    const PrefsLines = readFileSync(prefsPath, "utf-8").split("\n");
+    const filteredLines = PrefsLines.map((line) => {
+      if (
+        line.includes("extensions.lastAppBuildId") ||
+        line.includes("extensions.lastAppVersion")
+      ) {
+        return;
+      }
+      if (line.includes("extensions.zotero.dataDir") && dataDir !== "") {
+        return `user_pref("extensions.zotero.dataDir", "${dataDir}");`;
+      }
+      return line;
+    });
+    const updatedPrefs = filteredLines.join("\n");
+    writeFileSync(prefsPath, updatedPrefs, "utf-8");
+    console.log("The <profile>/prefs.js modified.");
+  }
+}
+
+const startZotero = `"${zoteroBinPath}" --debugger --purgecaches -profile ${profilePath}`;
 
 execSync(startZotero);
 exit(0);

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -52,6 +52,8 @@ if (existsSync(profilePath)) {
     writeFileSync(prefsPath, updatedPrefs, "utf-8");
     console.log("[info] The <profile>/prefs.js has been modified.");
   }
+} else {
+  throw new Error("The given Zotero profile does not exist.");
 }
 
 const startZotero = `"${zoteroBinPath}" --debugger --purgecaches -profile ${profilePath}`;

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -14,9 +14,23 @@ if (!existsSync(zoteroBinPath)) {
 
 if (existsSync(profilePath)) {
   const addonProxyFilePath = join(profilePath, `extensions/${addonID}`);
-  if (!existsSync(addonProxyFilePath)) {
-    console.log("Addon proxy file do not exist, creating it.");
-    writeFileSync(addonProxyFilePath, resolve("build/addon"));
+  const buildPath = resolve("build/addon");
+
+  function writeAddonProxyFile() {
+    writeFileSync(addonProxyFilePath, buildPath);
+    console.log(
+      `[info] Addon proxy file has been updated. \n
+      File path: ${addonProxyFilePath} \n
+      Addon path: ${buildPath} \n`
+    );
+  }
+
+  if (existsSync(addonProxyFilePath)) {
+    if (readFileSync(addonProxyFilePath, "utf-8") !== buildPath) {
+      writeAddonProxyFile();
+    }
+  } else {
+    writeAddonProxyFile();
   }
 
   const prefsPath = join(profilePath, "prefs.js");
@@ -36,7 +50,7 @@ if (existsSync(profilePath)) {
     });
     const updatedPrefs = filteredLines.join("\n");
     writeFileSync(prefsPath, updatedPrefs, "utf-8");
-    console.log("The <profile>/prefs.js modified.");
+    console.log("[info] The <profile>/prefs.js has been modified.");
   }
 }
 

--- a/scripts/zotero-cmd-default.json
+++ b/scripts/zotero-cmd-default.json
@@ -3,6 +3,18 @@
   "killZoteroWindows": "taskkill /f /im zotero.exe",
   "killZoteroUnix": "kill -9 $(ps -x | grep zotero)",
   "exec": {
-    "7": "/path/to/zotero7.exe"
+    "@comment-zoteroBinPath": "Please input the path of the Zotero binary file in `zoteroBinPath`.",
+    "@comment-zoteroBinPath-tip": "The path delimiter should be escaped as `\\` for win32.",
+    "zoteroBinPath": "/path/to/zotero.exe",
+
+    "@comment-profilePath": "Please input the path of the profile used for development in `profilePath`.",
+    "@comment-profilePath-tip": "If this field is kept empty, Zotero will start with the default profile.",
+    "@comment-profilePath-see": "https://www.zotero.org/support/kb/profile_directory",
+    "profilePath": "/path/to/profile",
+
+    "@comment-dataDir": "Please input the directory where the database is located in dataDir",
+    "@comment-dataDir-tip": "If this field is kept empty, Zotero will start with the default date.",
+    "@comment-dataDir-see": "https://www.zotero.org/support/zotero_data",
+    "dataDir": ""
   }
 }

--- a/scripts/zotero-cmd-default.json
+++ b/scripts/zotero-cmd-default.json
@@ -4,7 +4,7 @@
   "killZoteroUnix": "kill -9 $(ps -x | grep zotero)",
   "exec": {
     "@comment-zoteroBinPath": "Please input the path of the Zotero binary file in `zoteroBinPath`.",
-    "@comment-zoteroBinPath-tip": "The path delimiter should be escaped as `\\` for win32.",
+    "@comment-zoteroBinPath-tip": "The path delimiter should be escaped as `\\` for win32. The path is `*/Zotero.app/Contents/MacOS/zotero` for MacOS.",
     "zoteroBinPath": "/path/to/zotero.exe",
 
     "@comment-profilePath": "Please input the path of the profile used for development in `profilePath`.",


### PR DESCRIPTION
启动 Zotero 前：
- 检查是否存在 `<profile>/extensions/${addonID}` 文件，并确认文件内容是正确的插件路径
- 删除 `<profile>/prefs.js` 文件中的 `extensions.lastAppBuildId` 和 `extensions.lastAppVersion` 两行

这与 [`zotero-plugin`](https://github.com/retorquere/zotero-plugin/blob/master/bin/start.py) 的思路类似。


这有利于：
- 初次使用的开发者只需配置 Zotero 二进制文件路径和 profile 路径，不用自己建文件、改 prefs.js
- 维护多个插件的开发者只需要复制 `zotero-cmd.json` 到不同仓库，不再需要逐个上述操作
- 仓库本地路径变化后无需其他更改