### PR TITLE
Fix glob pattern in ReplaceInFileConfig.files

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-config-prettier": "^8.8.0",
     "prettier": "3.0.0",
     "release-it": "^16.1.0",
-    "replace-in-file": "^6.3.5",
+    "replace-in-file": "^7.0.1",
     "typescript": "^5.0.4",
     "zotero-types": "^1.0.14"
   }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -130,11 +130,11 @@ function replaceString() {
 
   const optionsAddon = {
     files: [
-      path.join(buildDir, "**/*.xhtml"),
-      path.join(buildDir, "**/*.json"),
-      path.join(buildDir, "addon/prefs.js"),
-      path.join(buildDir, "addon/manifest.json"),
-      path.join(buildDir, "addon/bootstrap.js"),
+      `${buildDir}/addon/**/*.xhtml`,
+      `${buildDir}/addon/**/*.json`,
+      `${buildDir}/addon/prefs.js`,
+      `${buildDir}/addon/manifest.json`,
+      `${buildDir}/addon/bootstrap.js`,
       "update.json",
     ],
     from: replaceFrom,
@@ -148,7 +148,7 @@ function replaceString() {
   const localeMessageMiss = new Set();
 
   const replaceResultFlt = replaceInFileSync({
-    files: [path.join(buildDir, "addon/**/*.ftl")],
+    files: [`${buildDir}/addon/locale/**/*.ftl`],
     processor: (fltContent) => {
       const lines = fltContent.split("\n");
       const prefixedLines = lines.map((line) => {
@@ -168,7 +168,7 @@ function replaceString() {
   });
 
   const replaceResultXhtml = replaceInFileSync({
-    files: [path.join(buildDir, "addon/**/*.xhtml")],
+    files: [`${buildDir}/addon/**/*.xhtml`],
     processor: (input) => {
       const matchs = [...input.matchAll(/(data-l10n-id)="(\S*)"/g)];
       matchs.map((match) => {


### PR DESCRIPTION
`ReplaceInFileConfig.files` 应为 glob模式列表，除非启用 `windowsPathsNoEscape`，否则 `\\` 无法识别。

replace-in-file 6.3.5 工作正常令人困惑，没搞明白为什么可以，不过还是根据 glob 的要求来嘛。

relate: https://github.com/adamreisnz/replace-in-file/issues/165 , https://github.com/isaacs/node-glob#options