### PR TITLE
fix: check manifest before start

### DIFF
--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -9,12 +9,18 @@ const { addonID } = details.config;
 const { zoteroBinPath, profilePath, dataDir } = cmd.exec;
 
 if (!existsSync(zoteroBinPath)) {
-  throw new Error("Zotero bin do no exist.");
+  throw new Error("Zotero binary does not exist.");
 }
 
 if (existsSync(profilePath)) {
   const addonProxyFilePath = path.join(profilePath, `extensions/${addonID}`);
   const buildPath = path.resolve("build/addon");
+
+  if (!existsSync(path.join(buildPath, "./manifest.json"))) {
+    throw new Error(
+      `The built file does not exist, maybe you need to build the addon first.`,
+    );
+  }
 
   function writeAddonProxyFile() {
     writeFileSync(addonProxyFilePath, buildPath);

--- a/scripts/zotero-cmd-default.json
+++ b/scripts/zotero-cmd-default.json
@@ -8,7 +8,7 @@
     "zoteroBinPath": "/path/to/zotero.exe",
 
     "@comment-profilePath": "Please input the path of the profile used for development in `profilePath`.",
-    "@comment-profilePath-tip": "If this field is kept empty, Zotero will start with the default profile.",
+    "@comment-profilePath-tip": "Start the profile manager by `/path/to/zotero.exe -p` to create a profile for development",
     "@comment-profilePath-see": "https://www.zotero.org/support/kb/profile_directory",
     "profilePath": "/path/to/profile",
 


### PR DESCRIPTION
- 如果启动Zotero时，`build/addon/manifest.json`不存在，则抛出错误。
- fix typo
- 修改zotero-cmd-default.json里的注释，事实上profilePath目前在脚本是必填项，因为脚本难以获取缺省profile的路径，就没法修改prefs.js等。