### PR TITLE
chore: change build outfile to addonRef.js

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -91,7 +91,7 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
   ctx._globalThis = ctx;
 
   Services.scriptloader.loadSubScript(
-    `${rootURI}/chrome/content/scripts/index.js`,
+    `${rootURI}/chrome/content/scripts/__addonRef__.js`,
     ctx,
   );
 }
@@ -111,7 +111,7 @@ function shutdown({ id, version, resourceURI, rootURI }, reason) {
     .getService(Components.interfaces.nsIStringBundleService)
     .flushBundles();
 
-  Cu.unload(`${rootURI}/chrome/content/scripts/index.js`);
+  Cu.unload(`${rootURI}/chrome/content/scripts/__addonRef__.js`);
 
   if (chromeHandle) {
     chromeHandle.destruct();

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -211,7 +211,10 @@ async function esbuild() {
     },
     bundle: true,
     target: "firefox102",
-    outfile: path.join(buildDir, "addon/chrome/content/scripts/index.js"),
+    outfile: path.join(
+      buildDir,
+      `addon/chrome/content/scripts/${config.addonRef}.js`,
+    ),
     // Don't turn minify on
     // minify: true,
   }).catch(() => exit(1));


### PR DESCRIPTION
将 edbuild 的输出文件名从 `index.js` 更改为`${config.addonRef}.js`，这对维护多个插件的开发者应是有利的，例如在控制台，开发者看到的就不是 `index.js` 了，这样不同插件打印的日志就比较好区分。

（部分时候并没有用 `ztoolkit.log`而是直接用了`console.log`；此外有部分插件开发和发布过程并没有区分既有的 dev 和 prod，改的时候不容易区分）



![Snipaste_2023-07-17_17-05-59](https://github.com/windingwind/zotero-plugin-template/assets/44738481/05421d0c-caf3-4faa-b82b-f674f542aac9)
