### PR TITLE
Remove original xpi file if exists in `extensions` folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Steps in `scripts/build.mjs`:
 - Create/empty `build/`.
 - Copy `addon/**` to `build/addon/**`
 - Replace placeholders: use `replace-in-file` to replace keywords and configurations defined in `package.json` in non-build files (`xhtml`, `json`, et al.).
-- Prepare locale files to [avaid conflict](https://www.zotero.org/support/dev/zotero_7_for_developers#avoiding_localization_conflicts)
+- Prepare locale files to [avoid conflict](https://www.zotero.org/support/dev/zotero_7_for_developers#avoiding_localization_conflicts)
   - Rename `**/*.flt` to `**/${addonRef}-*.flt`
   - Prefix each fluent message with `addonRef-`
 - Use Esbuild to build `.ts` source code to `.js`, build `src/index.ts` to `./build/addon/chrome/content/scripts`.

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -2,7 +2,7 @@ import details from "../package.json" assert { type: "json" };
 import { Logger } from "./utils.mjs";
 import cmd from "./zotero-cmd.json" assert { type: "json" };
 import { spawn } from "child_process";
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
 import { clearFolder } from "./utils.mjs";
 import path from "path";
 import { exit } from "process";
@@ -43,6 +43,11 @@ function prepareDevEnv() {
     }
   } else {
     writeAddonProxyFile();
+  }
+
+  const addonXpiFilePath = path.join(profilePath, `extensions/${addonID}.xpi`);
+  if (existsSync(addonXpiFilePath)) {
+    rmSync(addonXpiFilePath);
   }
 
   const prefsPath = path.join(profilePath, "prefs.js");


### PR DESCRIPTION
If Zotero has installed an add-on through the `install add-on from file` method. 
After running the `npm start` command, both the `{addonID}` and `{addonID}.xpi` files exist in the `{profilePath}/extensions` directory  
Zotero will load add-on from `{addonID}.xpi` instead of `{addonID}`. 
This behavior renders operations such as reloading ineffective for development purposes.

This PR simply removes the original `{addonID}.xpi` file. If there is a better approach, ignore this PR.