### PR TITLE
fix: only prompt version when run release, and submit comment to closed issues, fix prerelease version number breaks auto update

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stop": "node scripts/stop.mjs",
     "lint": "prettier --write . && eslint . --ext .ts --fix",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release": "release-it",
+    "release": "release-it --only-version",
     "update-deps": "npm update --save"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "stop": "node scripts/stop.mjs",
     "lint": "prettier --write . && eslint . --ext .ts --fix",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "release": "release-it --only-version",
+    "release": "release-it --only-version --preReleaseId=beta",
     "update-deps": "npm update --save"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,12 @@
       "release": false,
       "assets": [
         "build/*.xpi"
-      ]
+      ],
+      "comments": {
+        "submit": true,
+        "issue": ":rocket: _This issue has been resolved in v${version}. See [${releaseName}](${releaseUrl}) for release notes._",
+        "pr": ":rocket: _This pull request is included in v${version}. See [${releaseName}](${releaseUrl}) for release notes._"
+      }
     },
     "hooks": {
       "before:init": "npm run lint",


### PR DESCRIPTION
closes: #91

- 在运行 release-it 时仅选择版本号，自动 build ，commit，tag，push
- 向这个版本中包含的issue和pr提交评论。用户需要在提交信息中包含关闭 issue 的关键词，可以是在提交信息标题，也可在提交body。see https://github.com/release-it/release-it/blob/main/docs/github-releases.md#comments and https://www.npmjs.com/package/issue-parser#actions
- 修复默认预发布版本号破坏 Zotero 自动更新时的版本号比较。

---

- Select only the version number when running release-it, auto-build, commit, tag, push
- Submit comments to issues and prs included in this release. The user needs to include the keyword to close the issue in the commit message, either in the title of the commit message or in the body of the commit. see https://github.com/release-it/release-it/blob/main/docs/github-releases.md#comments and https://www.npmjs.com/package/issue-parser#actions
- Fix the default pre-release version number to break the version number comparison when Zotero auto-updates.