### PR TITLE
fix: esbuild breaks server, and debounced reload

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -15,6 +15,11 @@
       "update_url": "__updateURL__",
       "strict_min_version": "6.999",
       "strict_max_version": "7.0.*"
+    },
+    "gecko": {
+      "id": "__addonID__",
+      "update_url": "__updateURL__",
+      "strict_min_version": "102"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "release-it": "^17.0.1",
     "replace-in-file": "^7.0.2",
     "typescript": "^5.3.3",
+    "web-ext": "^7.9.0",
     "zotero-types": "^1.3.10"
   },
   "eslintConfig": {

--- a/scripts/server.mjs
+++ b/scripts/server.mjs
@@ -60,6 +60,7 @@ async function startWebExt() {
       firefoxProfile: profilePath,
       sourceDir: path.resolve("build/addon"),
       keepProfileChanges: true,
+      args: ["--debugger", "--purgecaches"],
       // browserConsole: true,
     },
     {

--- a/scripts/server.mjs
+++ b/scripts/server.mjs
@@ -28,17 +28,23 @@ async function watch() {
     })
     .on("change", async (path) => {
       Logger.info(`${path} changed.`);
-      if (path.startsWith("src")) {
-        await esbuildCTX.rebuild();
-      } else if (path.startsWith("addon")) {
-        await build()
-          // Do not abort the watcher when errors occur in builds triggered by the watcher.
-          .catch((err) => {
-            Logger.error(err);
-          });
+
+      async function rebuild() {
+        if (path.startsWith("src")) {
+          await esbuildCTX.rebuild();
+        } else if (path.startsWith("addon")) {
+          await build();
+        }
       }
-      // reload
-      reload();
+
+      await rebuild()
+        .then(() => {
+          reload();
+        })
+        // Do not abort the watcher when errors occur in builds triggered by the watcher.
+        .catch((err) => {
+          Logger.error(err);
+        });
     })
     .on("error", (err) => {
       Logger.error("Server start failed!", err);

--- a/scripts/server.mjs
+++ b/scripts/server.mjs
@@ -27,7 +27,7 @@ async function watch() {
       Logger.info("Server Ready! \n");
     })
     .on("change", async (path) => {
-      Logger.info(`${path} changed.`);
+      Logger.info(`${path} changed at ${new Date().toLocaleTimeString()}`);
 
       async function rebuild() {
         if (path.startsWith("src")) {

--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -27,22 +27,16 @@ if (!existsSync(profilePath)) {
 function prepareDevEnv() {
   const addonProxyFilePath = path.join(profilePath, `extensions/${addonID}`);
   const buildPath = path.resolve("build/addon");
-
-  function writeAddonProxyFile() {
+  if (
+    !existsSync(addonProxyFilePath) ||
+    readFileSync(addonProxyFilePath, "utf-8") !== buildPath
+  ) {
     writeFileSync(addonProxyFilePath, buildPath);
     Logger.debug(
       `Addon proxy file has been updated. 
-          File path: ${addonProxyFilePath} 
-          Addon path: ${buildPath} `,
+      File path: ${addonProxyFilePath} 
+      Addon path: ${buildPath} `,
     );
-  }
-
-  if (existsSync(addonProxyFilePath)) {
-    if (readFileSync(addonProxyFilePath, "utf-8") !== buildPath) {
-      writeAddonProxyFile();
-    }
-  } else {
-    writeAddonProxyFile();
   }
 
   const addonXpiFilePath = path.join(profilePath, `extensions/${addonID}.xpi`);


### PR DESCRIPTION
- 修复 esbuild rebuild 失败导致 server 退出的问题

    before:

    ![image](https://github.com/windingwind/zotero-plugin-template/assets/44738481/c5e0f73c-b8c1-41a5-b38c-1b24192d4571)


    after:

    ![image](https://github.com/windingwind/zotero-plugin-template/assets/44738481/5b143876-ff2d-49de-9caa-394f99bbd848)

- 打印文件更改时间，要不然一堆changed 也不知道这一次的保存到底改没改
- 1s 内多次触发的 reload 只执行一次，避免大量 reload 导致 Zotero 崩溃，同时设置 reload 的超时时间 8s，超时时（Zotero 通常已经未响应）则结束 Zotero