### PR TITLE
Fix: Unescaped dataDir path in start.mjs

### DIFF
--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -61,7 +61,7 @@ function prepareDevEnv() {
         return;
       }
       if (line.includes("extensions.zotero.dataDir") && dataDir !== "") {
-        return `user_pref("extensions.zotero.dataDir", "${dataDir}");`;
+        return `user_pref("extensions.zotero.dataDir", "${dataDir.replace(/\\\\?/g, "\\\\")}");`;
       }
       return line;
     });


### PR DESCRIPTION
Hi,

# Bug Description

In `zotero-cmd.json`, we are required to set the `dataDir` of Zotero, like: 

```json
  "exec": {
    "dataDir": "C:\\Zotero\\Data"
  }
```

In **Win32** platform, the value will be converted to `"C:\Zotero\Data"` in `start.mjs`, which is invalid in `prefs.js` and thus will be reverted to Zotero's default value: `C:\Users\<USERNAME>\Zotero`.

# Solutions

To fix or avoid this error, there are two solutions:

1. Set `dataDir` with 4 `\`, i.e., 
  ```json
  "exec": {
    "dataDir": "C:\\\\Zotero\\\\Data"
  }
  ```
2. Use regex to convert `dataDir` to the correct form [**Recommended**]
   As shown in this PR, just add `.replace(/\\\\?/g, "\\\\")` in https://github.com/windingwind/zotero-plugin-template/blob/0663e5b0b1b53db29d5374601a8dc10f24bdbdf4/scripts/start.mjs#L64

   It can convert both `\\` or `\\\\` to `\\` automatically.

Thanks!