### PR TITLE
Create extensions dir in start script

### DIFF
--- a/scripts/start.mjs
+++ b/scripts/start.mjs
@@ -2,7 +2,7 @@ import details from "../package.json" assert { type: "json" };
 import { Logger } from "./utils.mjs";
 import cmd from "./zotero-cmd.json" assert { type: "json" };
 import { spawn } from "child_process";
-import { existsSync, readFileSync, writeFileSync, rmSync } from "fs";
+import { existsSync, readFileSync, writeFileSync, rmSync, mkdirSync } from "fs";
 import { clearFolder } from "./utils.mjs";
 import path from "path";
 import { exit } from "process";
@@ -25,7 +25,8 @@ if (!existsSync(profilePath)) {
 }
 
 function prepareDevEnv() {
-  const addonProxyFilePath = path.join(profilePath, `extensions/${addonID}`);
+  const extensionsPath = path.join(profilePath, "extensions");
+  const addonProxyFilePath = path.join(extensionsPath, addonID);
   const buildPath = path.resolve("build/addon");
 
   function writeAddonProxyFile() {
@@ -42,6 +43,9 @@ function prepareDevEnv() {
       writeAddonProxyFile();
     }
   } else {
+    if (!existsSync(extensionsPath)) {
+      mkdirSync(extensionsPath);
+    }
     writeAddonProxyFile();
   }
 


### PR DESCRIPTION
Following quick-start guide, I get the following when running `npm start`:

```console
 [INFO] [Build] BUILD_DIR=build, VERSION=1.0.0-beta.0, BUILD_TIME=2024-04-13 21:09:27, ENV=development 
 [DEBUG] [Build] Replacing
 [DEBUG] [Build] Preparing locale files
 [DEBUG] [Build] Running esbuild
 [DEBUG] [Build] Addon prepare OK
 [ERROR] Error: ENOENT: no such file or directory, open '/home/aokellermann/.zotero/zotero/wj5l6rns.nexus/extensions/zotero-nexus@aokellermann.dev'
    at Object.open (node:internal/fs/sync:78:18)
    at Object.openSync (node:fs:565:17)
    at writeFileSync (node:fs:2288:35)
    at writeAddonProxyFile (file:///home/aokellermann/repos/zotero-nexus/scripts/start.mjs:33:5)
    at prepareDevEnv (file:///home/aokellermann/repos/zotero-nexus/scripts/start.mjs:49:5)
    at main (file:///home/aokellermann/repos/zotero-nexus/scripts/start.mjs:86:3)
    at main (file:///home/aokellermann/repos/zotero-nexus/scripts/server.mjs:71:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/home/aokellermann/.zotero/zotero/wj5l6rns.nexus/extensions/zotero-nexus@aokellermann.dev'
}
```
This is solved by creating the `extensions` directory under zotero profile.
