### PR TITLE
chore: bump eslint to v9

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-undef */
+
 /**
  * Most of this code is from Zotero team's official Make It Red example[1]
  * or the Zotero 7 documentation[2].

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,32 @@
+// @ts-check Let TS check this config file
+
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["build/**", "dist/**", "node_modules/**", "scripts/"],
+  },
+  {
+    extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
+    rules: {
+      "@typescript-eslint/ban-ts-comment": [
+        "warn",
+        {
+          "ts-expect-error": "allow-with-description",
+          "ts-ignore": "allow-with-description",
+          "ts-nocheck": "allow-with-description",
+          "ts-check": "allow-with-description",
+        },
+      ],
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-explicit-any": [
+        "off",
+        {
+          ignoreRestArgs: true,
+        },
+      ],
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "start": "zotero-plugin serve",
     "build": "tsc --noEmit && zotero-plugin build",
-    "lint": "prettier --write . && eslint . --ext .ts --fix",
+    "lint": "prettier --write . && eslint . --fix",
     "release": "zotero-plugin release",
     "test": "echo \"Error: no test specified\" && exit 1",
     "update-deps": "npm update --save"
@@ -31,65 +31,14 @@
     "zotero-plugin-toolkit": "^2.3.31"
   },
   "devDependencies": {
+    "@eslint/js": "^9.2.0",
     "@types/node": "^20.12.12",
-    "@typescript-eslint/eslint-plugin": "^7.9.0",
-    "@typescript-eslint/parser": "^7.9.0",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint": "^9.2.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
+    "typescript-eslint": "^7.9.0",
     "zotero-plugin-scaffold": "^0.0.22",
-    "zotero-types": "^1.3.24"
-  },
-  "eslintConfig": {
-    "env": {
-      "browser": true,
-      "es2021": true
-    },
-    "root": true,
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended",
-      "prettier"
-    ],
-    "overrides": [],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaVersion": "latest",
-      "sourceType": "module"
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "rules": {
-      "@typescript-eslint/ban-ts-comment": [
-        "warn",
-        {
-          "ts-expect-error": "allow-with-description",
-          "ts-ignore": "allow-with-description",
-          "ts-nocheck": "allow-with-description",
-          "ts-check": "allow-with-description"
-        }
-      ],
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-explicit-any": [
-        "off",
-        {
-          "ignoreRestArgs": true
-        }
-      ],
-      "@typescript-eslint/no-non-null-assertion": "off"
-    },
-    "ignorePatterns": [
-      "**/.vscode/**",
-      "**/build/**",
-      "**/logs/**",
-      "**/dist/**",
-      "**/node_modules/**",
-      "**/scripts/**",
-      "**/*.js",
-      "**/*.bak"
-    ]
+    "zotero-types": "^2.0.0"
   },
   "prettier": {
     "printWidth": 80,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -40,7 +40,7 @@ async function onMainWindowLoad(win: Window): Promise<void> {
   // Create ztoolkit for every window
   addon.data.ztoolkit = createZToolkit();
 
-  // @ts-ignore
+  // @ts-ignore This is a moz feature
   window.MozXULElement.insertFTLIfNeeded(`${config.addonRef}-mainWindow.ftl`);
 
   const popupWin = new ztoolkit.ProgressWindow(config.addonName, {


### PR DESCRIPTION
run `npx @eslint/config-inspector` to see rules and config.

Global: ignore `["build/**", "dist/**", "node_modules/**", "scripts/"],`

All files (may *.js, *.mjs, *.cjs): eslint.configs.recommended

All ts files: tseslint.configs.recommended with some rule off