### PR TITLE
fix: migrate to esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "zotero-plugin-template",
+  "type": "module",
   "version": "3.0.3",
   "description": "Zotero Plugin Template",
   "config": {

--- a/src/addon.ts
+++ b/src/addon.ts
@@ -1,6 +1,5 @@
 import { config } from "../package.json";
-import { ColumnOptions } from "zotero-plugin-toolkit/dist/helpers/virtualizedTable";
-import { DialogHelper } from "zotero-plugin-toolkit/dist/helpers/dialog";
+import { ColumnOptions, DialogHelper } from "zotero-plugin-toolkit";
 import hooks from "./hooks";
 import { createZToolkit } from "./utils/ztoolkit";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true,
-    "module": "commonjs",
     "target": "ES2016",
+    "lib": ["ESNext"],
+    "experimentalDecorators": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "skipDefaultLibCheck": true,
-    "strict": true
+    "types": ["zotero-types"],
+    "strict": true,
+    "outDir": "build/dist/",
+    "skipLibCheck": true
   },
-  "include": ["src", "typings", "node_modules/zotero-types"],
+  "include": ["src", "typings"],
   "exclude": ["build", "addon"]
 }


### PR DESCRIPTION

This is an additional fix for https://github.com/windingwind/zotero-plugin-template/commit/b91b90718d9fd4911a13c9918620329a66f5427c.

Also, some tsconfig changes have been made to make it more logical. Some import errors should now also be caught by tsc.

Note that `zotero-types` has been moved to `types` instead of `includes`, which ensures that pnpm can also work without having to set `public-hoist-pattern`.