### PR TITLE
feat: add `@zotero-plugin/eslint-config`

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 /**
  * Most of this code is from Zotero team's official Make It Red example[1]
  * or the Zotero 7 documentation[2].
@@ -33,9 +31,7 @@ async function startup({ id, version, resourceURI, rootURI }, reason) {
    * and all child variables assigned to it is globally accessible.
    * See `src/index.ts` for details.
    */
-  const ctx = {
-    rootURI,
-  };
+  const ctx = { rootURI };
   ctx._globalThis = ctx;
 
   Services.scriptloader.loadSubScript(

--- a/addon/prefs.js
+++ b/addon/prefs.js
@@ -1,3 +1,2 @@
-/* eslint-disable no-undef */
 pref("enable", true);
 pref("input", "This is input");

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,46 +1,16 @@
 // @ts-check Let TS check this config file
 
-import eslint from "@eslint/js";
-import tseslint from "typescript-eslint";
+import zotero from "@zotero-plugin/eslint-config";
 
-export default tseslint.config(
-  {
-    ignores: ["build/**", ".scaffold/**", "node_modules/**", "scripts/"],
-  },
-  {
-    extends: [eslint.configs.recommended, ...tseslint.configs.recommended],
-    rules: {
-      "no-restricted-globals": [
-        "error",
-        { message: "Use `Zotero.getMainWindow()` instead.", name: "window" },
-        {
-          message: "Use `Zotero.getMainWindow().document` instead.",
-          name: "document",
-        },
-        {
-          message: "Use `Zotero.getActiveZoteroPane()` instead.",
-          name: "ZoteroPane",
-        },
-        "Zotero_Tabs",
-      ],
-
-      "@typescript-eslint/ban-ts-comment": [
-        "warn",
-        {
-          "ts-expect-error": "allow-with-description",
-          "ts-ignore": "allow-with-description",
-          "ts-nocheck": "allow-with-description",
-          "ts-check": "allow-with-description",
-        },
-      ],
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/no-explicit-any": [
-        "off",
-        {
-          ignoreRestArgs: true,
-        },
-      ],
-      "@typescript-eslint/no-non-null-assertion": "off",
+export default zotero({
+  overrides: [
+    {
+      files: ["**/*.ts"],
+      rules: {
+        // We disable this rule here because the template
+        // contains some unused examples and variables
+        "@typescript-eslint/no-unused-vars": "off",
+      },
     },
-  },
-);
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.15.30",
-        "@zotero-plugin/eslint-config": "^0.6.3",
+        "@zotero-plugin/eslint-config": "^0.6.6",
         "eslint": "^9.28.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",
@@ -1825,14 +1825,15 @@
       }
     },
     "node_modules/@zotero-plugin/eslint-config": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@zotero-plugin/eslint-config/-/eslint-config-0.6.3.tgz",
-      "integrity": "sha512-njLSR03P9INt6vmAoqW3ZqYJkbOx+7j72jpeYDSgW+vKnA9WU1xDRT+/Bgn9fPeJersviLl49sW6TTVFjMtMcQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@zotero-plugin/eslint-config/-/eslint-config-0.6.6.tgz",
+      "integrity": "sha512-ucKe9SgtIYOWC9MqScM4QVgbnIWk4BzyCT8gJtQa9wb3/dXqAWwOeKJQRXKYOEgLSJ+qwtvUDIvDH1n67tcBwQ==",
       "dev": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@eslint/js": "^9.28.0",
         "eslint-config-flat-gitignore": "^2.1.0",
+        "eslint-plugin-chai-friendly": "^1.1.0",
         "eslint-plugin-mocha": "^11.1.0",
         "typescript-eslint": "^8.34.0"
       },
@@ -2460,6 +2461,19 @@
       },
       "peerDependencies": {
         "eslint": "^9.5.0"
+      }
+    },
+    "node_modules/eslint-plugin-chai-friendly": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.1.0.tgz",
+      "integrity": "sha512-+T1rClpDdXkgBAhC16vRQMI5umiWojVqkj9oUTdpma50+uByCZM/oBfxitZiOkjMRlm725mwFfz/RVgyDRvCKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=3.0.0"
       }
     },
     "node_modules/eslint-plugin-mocha": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "zotero-plugin-toolkit": "^5.0.0"
       },
       "devDependencies": {
-        "@types/node": "^22.15.3",
+        "@types/node": "^22.15.30",
         "@zotero-plugin/eslint-config": "^0.6.3",
-        "eslint": "^9.25.1",
+        "eslint": "^9.28.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",
         "zotero-plugin-scaffold": "^0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,11 @@
         "zotero-plugin-toolkit": "^5.0.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.25.1",
-        "@types/node": "^22.15.30",
-        "eslint": "^9.28.0",
+        "@types/node": "^22.15.3",
+        "@zotero-plugin/eslint-config": "^0.6.3",
+        "eslint": "^9.25.1",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.34.0",
         "zotero-plugin-scaffold": "^0.6.0",
         "zotero-types": "^4.0.3"
       }
@@ -487,6 +486,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/compat": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.9.tgz",
+      "integrity": "sha512-gCdSY54n7k+driCadyMNv8JSPzYLeDVM/ikZRtvtROBpRdFSkS8W9A82MqsaY7lZuwL0wiapgD0NT1xT0hyJsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.10.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/config-array": {
@@ -1807,6 +1824,25 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@zotero-plugin/eslint-config": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@zotero-plugin/eslint-config/-/eslint-config-0.6.3.tgz",
+      "integrity": "sha512-njLSR03P9INt6vmAoqW3ZqYJkbOx+7j72jpeYDSgW+vKnA9WU1xDRT+/Bgn9fPeJersviLl49sW6TTVFjMtMcQ==",
+      "dev": true,
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@eslint/js": "^9.28.0",
+        "eslint-config-flat-gitignore": "^2.1.0",
+        "eslint-plugin-mocha": "^11.1.0",
+        "typescript-eslint": "^8.34.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^9.28.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2408,6 +2444,49 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-flat-gitignore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-flat-gitignore/-/eslint-config-flat-gitignore-2.1.0.tgz",
+      "integrity": "sha512-cJzNJ7L+psWp5mXM7jBX+fjHtBvvh06RBlcweMhKD8jWqQw0G78hOW5tpVALGHGFPsBV+ot2H+pdDGJy6CV8pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/compat": "^1.2.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "eslint": "^9.5.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-11.1.0.tgz",
+      "integrity": "sha512-rKntVWRsQFPbf8OkSgVNRVRrcVAPaGTyEgWCEyXaPDJkTl0v5/lwu1vTk5sWiUJU8l2sxwvGUZzSNrEKdVMeQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.1",
+        "globals": "^15.14.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-mocha/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,11 @@
     "zotero-plugin-toolkit": "^5.0.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.25.1",
-    "@types/node": "^22.15.30",
-    "eslint": "^9.28.0",
+    "@types/node": "^22.15.3",
+    "@zotero-plugin/eslint-config": "^0.6.3",
+    "eslint": "^9.25.1",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.34.0",
     "zotero-plugin-scaffold": "^0.6.0",
     "zotero-types": "^4.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "zotero-plugin-toolkit": "^5.0.0"
   },
   "devDependencies": {
-    "@types/node": "^22.15.3",
+    "@types/node": "^22.15.30",
     "@zotero-plugin/eslint-config": "^0.6.3",
-    "eslint": "^9.25.1",
+    "eslint": "^9.28.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",
     "zotero-plugin-scaffold": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.30",
-    "@zotero-plugin/eslint-config": "^0.6.3",
+    "@zotero-plugin/eslint-config": "^0.6.6",
     "eslint": "^9.28.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -43,7 +43,6 @@ async function onMainWindowLoad(win: _ZoteroTypes.MainWindow): Promise<void> {
   // Create ztoolkit for every window
   addon.data.ztoolkit = createZToolkit();
 
-  // @ts-ignore This is a moz feature
   win.MozXULElement.insertFTLIfNeeded(
     `${addon.data.config.addonRef}-mainWindow.ftl`,
   );
@@ -100,7 +99,7 @@ function onShutdown(): void {
   addon.data.dialog?.window?.close();
   // Remove addon object
   addon.data.alive = false;
-  // @ts-ignore - Plugin instance is not typed
+  // @ts-expect-error - Plugin instance is not typed
   delete Zotero[addon.data.config.addonInstance];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,13 +4,13 @@ import { config } from "../package.json";
 
 const basicTool = new BasicTool();
 
-// @ts-ignore - Plugin instance is not typed
+// @ts-expect-error - Plugin instance is not typed
 if (!basicTool.getGlobal("Zotero")[config.addonInstance]) {
   _globalThis.addon = new Addon();
   defineGlobal("ztoolkit", () => {
     return _globalThis.addon.data.ztoolkit;
   });
-  // @ts-ignore - Plugin instance is not typed
+  // @ts-expect-error - Plugin instance is not typed
   Zotero[config.addonInstance] = addon;
 }
 

--- a/src/modules/examples.ts
+++ b/src/modules/examples.ts
@@ -445,7 +445,7 @@ export class PromptExampleFactory {
           s.addCondition("itemType", "isNot", "attachment");
           let ids = await s.search();
           // prompt.exit will remove current container element.
-          // @ts-ignore ignore
+          // @ts-expect-error ignore
           prompt.exit();
           const container = prompt.createCommandsContainer();
           container.classList.add("suggestions");
@@ -506,7 +506,7 @@ export class PromptExampleFactory {
                   {
                     type: "mousemove",
                     listener: function () {
-                      // @ts-ignore ignore
+                      // @ts-expect-error ignore
                       prompt.selectItem(this);
                     },
                   },
@@ -553,7 +553,7 @@ export class PromptExampleFactory {
               container.appendChild(ele);
             });
           } else {
-            // @ts-ignore ignore
+            // @ts-expect-error ignore
             prompt.exit();
             prompt.showTip("Not Found.");
           }


### PR DESCRIPTION
## info

`@zotero-plugin/eslint-config`: 

homepage: https://northword.github.io/zotero-plugin-scaffold/eslint.html
repo: https://github.com/northword/zotero-plugin-scaffold/tree/main/packages/eslint-config

## todo

### no-restricted-globals

Do the following rules actually work?



```js
      "no-restricted-globals": [
        "error",
        { message: "Use `Zotero.getMainWindow()` instead.", name: "window" },
        {
          message: "Use `Zotero.getMainWindow().document` instead.",
          name: "document",
        },
        {
          message: "Use `Zotero.getActiveZoteroPane()` instead.",
          name: "ZoteroPane",
        },
        "Zotero_Tabs",
      ],
```

如果是，我们需要屏蔽所有浏览器变量吗？

-> https://github.com/sindresorhus/globals/blob/main/data/browser.mjs

### @typescript-eslint/no-unused-vars

The following rule is recommended to be enabled, but the template example has a lot of unused function arguments.

https://typescript-eslint.io/rules/no-unused-vars/

```js
    "@typescript-eslint/no-unused-vars": ["error", {
      argsIgnorePattern: "^_",
      varsIgnorePattern: "^_",
    }],
```
