### PR TITLE
fix: getString with branch

### DIFF
--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -61,7 +61,7 @@ function getString(...inputs: any[]) {
 }
 
 interface Pattern {
-  value: string;
+  value: string | null;
   attributes: Array<{
     name: string;
     value: string;

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -60,6 +60,14 @@ function getString(...inputs: any[]) {
   }
 }
 
+interface Pattern {
+  value: string;
+  attributes: Array<{
+    name: string;
+    value: string;
+  }> | null;
+}
+
 function _getString(
   localeString: FluentMessageId,
   options: { branch?: string | undefined; args?: Record<string, unknown> } = {},
@@ -68,17 +76,16 @@ function _getString(
   const { branch, args } = options;
   const pattern = addon.data.locale?.current.formatMessagesSync([
     { id: localStringWithPrefix, args },
-  ])[0];
+  ])[0] as Pattern;
+
   if (!pattern) {
     return localStringWithPrefix;
   }
   if (branch && pattern.attributes) {
-    for (const attr of pattern.attributes) {
-      if (attr.name === branch) {
-        return attr.value;
-      }
-    }
-    return pattern.attributes[branch] || localStringWithPrefix;
+    return (
+      pattern.attributes.find((attr) => attr.name === branch)?.value ||
+      localStringWithPrefix
+    );
   } else {
     return pattern.value || localStringWithPrefix;
   }


### PR DESCRIPTION
ref: https://github.com/northword/zotero-format-metadata/issues/358

<img width="1596" height="322" alt="image" src="https://github.com/user-attachments/assets/3a2de9cd-3a74-40f6-91c6-5ba828499060" />

`attributes` is an array instead of object.